### PR TITLE
Fix typescript definitions to work without require

### DIFF
--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -1,1 +1,3 @@
-export default function (url: string, rules: string|Array<string>|void): boolean;
+declare namespace matchUrl { }
+declare function matchUrl(url: string, rules: string | Array<string> | void): boolean;
+export = matchUrl;


### PR DESCRIPTION
With the current Typescript definitions you cannot use Typescripts approach of importing modules, i.e. `import matchUrl from 'match-url-wildcard'` will not work. Instead you have to use either 
`import matchUrl = require('match-url-wildcard')` or 
`const matchUrl = require('match-url-wildcard')`

With this fix you can import the module, instead of having to use require, as: 
`import * as matchUrl from 'match-url-wildcard'` 